### PR TITLE
whitespace only name fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ __pycache__/
 assets/
 queue/
 delete/
+
+venv/*
+*.mp4
+*.jpg
+*.png

--- a/comment_list_brige.py
+++ b/comment_list_brige.py
@@ -1,9 +1,15 @@
 import requests
 from objection_engine.beans.comment import Comment as obj_comment
+from objection_engine.beans.text import AnimText
 
 class Comment:
     def __init__(self, tweet):
-        self.author_name = tweet.user.name
+        # check if username is renderable, if not, use their "screen_name"
+        self.username_text = AnimText(tweet.user.name)
+        if self.is_username_renderable():
+            self.author_name = tweet.user.name
+        else:
+            self.author_name = f"@{tweet.user.screen_name}"
         self.author_id = tweet.user.id_str
         self.body = tweet.full_text
         self.evidence = None
@@ -17,3 +23,9 @@ class Comment:
             self.evidence = name
     def to_message(self) -> obj_comment:
         return obj_comment(user_id=self.author_id, user_name = self.author_name, text_content=self.body, evidence_path=self.evidence)
+
+    def is_username_renderable(self):
+        score = 0
+        for font in self.username_text.font_array:
+            score = max(score, self.username_text._check_font(font))
+        return score >= len(self.username_text._internal_text)


### PR DESCRIPTION
Solves #55 

**What's changed?**
- Included text / font scoring code in Comment, which will fall back to a user's "screen_name" if their "name" isn't properly renderable.
- Included venv/ and others in the .gitignore

**Test Cases**
Test thread: https://twitter.com/tmoll_/status/1516931029633667072?s=20&t=msFYZQ2HP_chV_cB9c77kg
Result: [link](https://cdn.moll.dev/content/media/random/1517295654728437761.mp4)

Another Test Thread with normal usernames: https://twitter.com/TwitterDev/status/1511757922354663425?s=20&t=msFYZQ2HP_chV_cB9c77kg
Result: [link](https://molldevblob.blob.core.windows.net/content/media/random/1517296504209170432.mp4)